### PR TITLE
Multi currency support for checkout

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,9 +5,8 @@ function priceFormat(amountInCents, currencySymbol) {
   return currencySymbol + (amountInCents / 100).toFixed(2).replace(/\B(?=(\d{3})+(?!\d))/g, ',');
 }
 
-function priceFormatMultiCurrency(unitAmount, currencyCode, currencySymbol) {
+function priceFormatMultiCurrency(unitAmount, currencyCode) {
   currencyCode = currencyCode || 'usd';
-  currencySymbol = currencySymbol || '$';
   const intlFormat = new Intl.NumberFormat(undefined, {
     currency: currencyCode,
     style: 'currency'
@@ -17,12 +16,7 @@ function priceFormatMultiCurrency(unitAmount, currencyCode, currencySymbol) {
 
   const formattedAmount = unitAmount / (10 ** currencyDecimalPlaces);
 
-  //add comma and decimal separators
-  const withSeparatorsAmount = intlFormat.format(formattedAmount);
-  //remove leading prefix
-  const withoutPrefixAmount = withSeparatorsAmount.replace(/^[^\d]*/g, '');
-  //add currency symbol
-  return `${currencySymbol}${withoutPrefixAmount}`;
+  return intlFormat.format(formattedAmount);
 }
 
 function discountable(amountInCents, percentOff, amountOffInCents) {
@@ -127,12 +121,12 @@ function totalLineOne(orderItem, currencySymbol) {
   }
 }
 
-function totalLineOneMulticurrency(orderItem, currencyCode, currencySymbol) {
+function totalLineOneMulticurrency(orderItem, currencyCode) {
   let total, totalWithInterval;
   if (totalDueNowMulticurrency(orderItem) === 0) {
     total = totalWithInterval = 'Free';
   } else {
-    total = priceFormatMultiCurrency(totalDueNowMulticurrency(orderItem), currencyCode, currencySymbol);
+    total = priceFormatMultiCurrency(totalDueNowMulticurrency(orderItem), currencyCode);
     totalWithInterval = total + ' / ' + orderItem.interval;
   }
 
@@ -157,9 +151,9 @@ function totalLineTwo(orderItem, currencySymbol) {
   }
 }
 
-function totalLineTwoMulticurrency(orderItem, currencyCode, currencySymbol) {
+function totalLineTwoMulticurrency(orderItem, currencyCode) {
   if (orderItem.purchasableType === 'bundle' && !orderItem.gift && orderItem.coupon && orderItem.coupon.duration !== 'forever') {
-    return priceFormatMultiCurrency(totalRecurringMulticurrency(orderItem), currencyCode, currencySymbol) + ' / ' + orderItem.interval;
+    return priceFormatMultiCurrency(totalRecurringMulticurrency(orderItem), currencyCode) + ' / ' + orderItem.interval;
   } else {
     return null;
   }

--- a/index.js
+++ b/index.js
@@ -5,6 +5,26 @@ function priceFormat(amountInCents, currencySymbol) {
   return currencySymbol + (amountInCents / 100).toFixed(2).replace(/\B(?=(\d{3})+(?!\d))/g, ',');
 }
 
+function priceFormatMultiCurrency(unitAmount, currencyCode, currencySymbol) {
+  currencyCode = currencyCode || 'usd';
+  currencySymbol = currencySymbol || '$';
+  const intlFormat = new Intl.NumberFormat(undefined, {
+    currency: currencyCode,
+    style: 'currency'
+  });
+
+  const { minimumFractionDigits: currencyDecimalPlaces } = intlFormat.resolvedOptions();
+
+  const formattedAmount = unitAmount / (10 ** currencyDecimalPlaces);
+
+  //add comma and decimal separators
+  const withSeparatorsAmount = intlFormat.format(formattedAmount);
+  //remove leading prefix
+  const withoutPrefixAmount = withSeparatorsAmount.replace(/^[^\d]*/g, '');
+  //add currency symbol
+  return `${currencySymbol}${withoutPrefixAmount}`;
+}
+
 function discountable(amountInCents, percentOff, amountOffInCents) {
   var discount, appliedDiscount;
 
@@ -56,6 +76,34 @@ function totalDueNow(orderItem) {
   }
 }
 
+function totalDueNowMulticurrency(orderItem) {
+  if (orderItem.total) {
+    return orderItem.total;
+  } else {
+    let quantity = orderItem.quantity || 0,
+        total = orderItem.price.unitAmount;
+    let totalUnitAmountOff;
+
+    if (orderItem.variation) {
+      total += (orderItem.variation.unitAmount || orderItem.variation.priceInCents || 0);
+    }
+
+    if (orderItem.coupon) {
+      if ((orderItem.purchasableType === 'bundle' || orderItem.isBulkPurchase) && quantity > 1) {
+        total = total * quantity;
+
+        if (orderItem.isBulkPurchase && orderItem.coupon.amountOffInCents) {
+          totalUnitAmountOff = orderItem.coupon.amountOffInCents * quantity
+        }
+
+        quantity = 1;
+      }
+      total = Math.round(discountable(total, orderItem.coupon.percentOff, totalUnitAmountOff || orderItem.coupon.amountOffInCents));
+    }
+    return total * quantity;
+  }
+}
+
 // TODO: figure out i18n story here
 function totalLineOne(orderItem, currencySymbol) {
   var total, totalWithInterval;
@@ -79,9 +127,40 @@ function totalLineOne(orderItem, currencySymbol) {
   }
 }
 
+function totalLineOneMulticurrency(orderItem, currencyCode, currencySymbol) {
+  let total, totalWithInterval;
+  if (totalDueNowMulticurrency(orderItem) === 0) {
+    total = totalWithInterval = 'Free';
+  } else {
+    total = priceFormatMultiCurrency(totalDueNowMulticurrency(orderItem), currencyCode, currencySymbol);
+    totalWithInterval = total + ' / ' + orderItem.interval;
+  }
+
+  if (orderItem.purchasableType === 'bundle' && !orderItem.gift) {
+    if (orderItem.coupon && orderItem.coupon.duration === 'repeating') {
+      return totalWithInterval + ' for the first ' + orderItem.coupon.durationInMonths + ' months';
+    } else if (orderItem.coupon && orderItem.coupon.duration === 'once') {
+      return total + ' for the first ' + orderItem.interval;
+    } else {
+      return totalWithInterval;
+    }
+  } else {
+    return total;
+  }
+}
+
 function totalLineTwo(orderItem, currencySymbol) {
   if (orderItem.purchasableType === 'bundle' && !orderItem.gift && orderItem.coupon && orderItem.coupon.duration !== 'forever') {
     return priceFormat(totalRecurring(orderItem), currencySymbol) + ' / ' + orderItem.interval;
+  } else {
+    return null;
+  }
+}
+
+function totalLineTwoMulticurrency(orderItem, currencyCode, currencySymbol) {
+  if (orderItem.purchasableType === 'bundle' && !orderItem.gift && orderItem.coupon && orderItem.coupon.duration !== 'forever') {
+    console.log('here');
+    return priceFormatMultiCurrency(totalRecurringMulticurrency(orderItem), currencyCode, currencySymbol) + ' / ' + orderItem.interval;
   } else {
     return null;
   }
@@ -111,13 +190,32 @@ function totalRecurring(orderItem) {
   }
 }
 
+function totalRecurringMulticurrency(orderItem) {
+  if (orderItem.purchasableType === 'bundle') {
+    if (orderItem.coupon && orderItem.coupon.duration === 'forever') {
+      console.log('forever');
+      // 'due now' discount applies forever
+      return totalDueNowMulticurrency(orderItem);
+    } else {
+      console.log('orderItem :>> ', orderItem);
+      return (orderItem.price?.unitAmount || 0) * (orderItem.quantity || 1);
+    }
+  } else {
+    return null;
+  }
+}
+
 var couponable = {
   discountable: discountable,
   totalLineOne: totalLineOne,
+  totalLineOneMulticurrency: totalLineOneMulticurrency,
   totalLineTwo: totalLineTwo,
+  totalLineTwoMulticurrency: totalLineTwoMulticurrency,
   totalDescription: totalDescription,
   totalDueNow: totalDueNow,
-  totalRecurring: totalRecurring
+  totalDueNowMulticurrency: totalDueNowMulticurrency,
+  totalRecurring: totalRecurring,
+  totalRecurringMulticurrency: totalRecurringMulticurrency
 };
 
 if (typeof module !== 'undefined' && module.exports) {

--- a/index.js
+++ b/index.js
@@ -159,7 +159,6 @@ function totalLineTwo(orderItem, currencySymbol) {
 
 function totalLineTwoMulticurrency(orderItem, currencyCode, currencySymbol) {
   if (orderItem.purchasableType === 'bundle' && !orderItem.gift && orderItem.coupon && orderItem.coupon.duration !== 'forever') {
-    console.log('here');
     return priceFormatMultiCurrency(totalRecurringMulticurrency(orderItem), currencyCode, currencySymbol) + ' / ' + orderItem.interval;
   } else {
     return null;
@@ -193,11 +192,9 @@ function totalRecurring(orderItem) {
 function totalRecurringMulticurrency(orderItem) {
   if (orderItem.purchasableType === 'bundle') {
     if (orderItem.coupon && orderItem.coupon.duration === 'forever') {
-      console.log('forever');
       // 'due now' discount applies forever
       return totalDueNowMulticurrency(orderItem);
     } else {
-      console.log('orderItem :>> ', orderItem);
       return (orderItem.price?.unitAmount || 0) * (orderItem.quantity || 1);
     }
   } else {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "couponable",
-  "version": "6.1.0",
+  "version": "6.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "couponable",
   "description": "Helper functions for dealing with coupons.",
-  "version": "6.2.0",
+  "version": "6.3.0",
   "author": "Chris McC",
   "license": "MIT",
   "repository": {

--- a/test.js
+++ b/test.js
@@ -237,8 +237,7 @@ describe('totalLineOneMulticurrency', function() {
             unitAmount: 200000
           }
         },
-        'usd',
-        '$'
+        'usd'
       ), '$2,000.00');
     });
     
@@ -250,8 +249,7 @@ describe('totalLineOneMulticurrency', function() {
             unitAmount: 4505
           }
         },
-        'jpy',
-        '¥'
+        'jpy'
       ), '¥4,505');
     });
 
@@ -263,8 +261,7 @@ describe('totalLineOneMulticurrency', function() {
             unitAmount: 350002
           }
         },
-        'eur',
-        '€'
+        'eur'
       ), '€3,500.02');
     });
 
@@ -277,8 +274,7 @@ describe('totalLineOneMulticurrency', function() {
             unitAmount: 2
           }
         },
-        'usd',
-        '$'
+        'usd'
       ), 'Free');
     });
   });
@@ -393,8 +389,7 @@ describe('totalLineTwoMulticurrency', function() {
             unitAmount: 6
           }
         }, 
-        'gbp',
-        '£'), '£0.06 / month');
+        'gbp'), '£0.06 / month');
     });
 
 


### PR DESCRIPTION
Related to CLM-8931

Adds multi-currency versions of methods used during the checkout process. Mainly focused on grabbing pricing data off of the `price` field as well as formatting for currencies without two decimal places (e.g. yen has zero).  Coupons for multi-currency are not set to be addressed fully until some point during Q1 2024. However, some changes needed to be made now as `cart-modal`, `ti-order-item`, `ti-order-summary` are a part of the checkout flow being updated in CLM-8931. Chose to go with separate methods instead of updates to existing methods to reduce risk of breaking changes for non-Foxy stores and lessen the testing effort for this particular ticket.