### PR TITLE
add locale to MC formatting

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,9 +5,10 @@ function priceFormat(amountInCents, currencySymbol) {
   return currencySymbol + (amountInCents / 100).toFixed(2).replace(/\B(?=(\d{3})+(?!\d))/g, ',');
 }
 
-function priceFormatMultiCurrency(unitAmount, currencyCode) {
+function priceFormatMultiCurrency(unitAmount, currencyCode, locale) {
   currencyCode = currencyCode || 'usd';
-  const intlFormat = new Intl.NumberFormat(undefined, {
+  locale = locale.replace('_', '-');
+  const intlFormat = new Intl.NumberFormat(locale, {
     currency: currencyCode,
     style: 'currency'
   });
@@ -150,7 +151,11 @@ function totalLineOneMulticurrency(orderItem, currencyCode) {
   if (totalDueNowMulticurrency(orderItem) === 0) {
     total = totalWithInterval = 'Free';
   } else {
-    total = priceFormatMultiCurrency(totalDueNowMulticurrency(orderItem), currencyCode);
+    total = priceFormatMultiCurrency(
+      totalDueNowMulticurrency(orderItem),
+      currencyCode,
+      orderItem.price.locale
+    );
     totalWithInterval = total + ' / ' + orderItem.interval;
   }
 
@@ -188,7 +193,11 @@ function totalLineTwoMulticurrency(orderItem, currencyCode) {
     orderItem.coupon.duration !== 'forever'
   ) {
     return (
-      priceFormatMultiCurrency(totalRecurringMulticurrency(orderItem), currencyCode) +
+      priceFormatMultiCurrency(
+        totalRecurringMulticurrency(orderItem),
+        currencyCode,
+        orderItem.price.locale
+      ) +
       ' / ' +
       orderItem.interval
     );

--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ function priceFormat(amountInCents, currencySymbol) {
 }
 
 function priceFormatMultiCurrency(unitAmount, currencyCode, locale) {
-  currencyCode = currencyCode || 'usd';
+  currencyCode = currencyCode || 'USD';
   locale = locale.replace('_', '-');
   const intlFormat = new Intl.NumberFormat(locale, {
     currency: currencyCode,

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "couponable",
   "description": "Helper functions for dealing with coupons.",
-  "version": "6.4.0",
+  "version": "6.4.1",
   "author": "Chris McC",
   "license": "MIT",
   "repository": {

--- a/test.js
+++ b/test.js
@@ -75,7 +75,8 @@ describe('totalDueNowMulticurrency', function () {
         quantity: 2,
         variation: { priceInCents: 2 },
         price: {
-          unitAmount: 2
+          unitAmount: 2,
+          locale: 'en_US'
         }
       }),
       8
@@ -122,7 +123,8 @@ describe('totalDueNowMulticurrency', function () {
         quantity: 10,
         coupon: { amountOffInCents: 5 },
         price: {
-          unitAmount: 10
+          unitAmount: 10,
+          locale: 'en_US'
         },
         purchasableType: 'course',
         isBulkPurchase: true
@@ -139,7 +141,8 @@ describe('totalDueNowMulticurrency', function () {
         learningPaths: ['lp-1'],
         courses: ['course-1'],
         price: {
-          unitsAmount: [500, 600]
+          unitsAmount: [500, 600],
+          locale: 'en_US'
         },
         purchasableType: 'pickableGroup'
       }),
@@ -152,7 +155,8 @@ describe('totalDueNowMulticurrency', function () {
         learningPaths: ['lp-1'],
         courses: [],
         price: {
-          unitsAmount: [500, 600]
+          unitsAmount: [500, 600],
+          locale: 'en_US'
         },
         purchasableType: 'pickableGroup'
       }),
@@ -167,7 +171,8 @@ describe('totalDueNowMulticurrency', function () {
         interval: 'year',
         price: {
           annualUnitAmount: 10000,
-          unitAmount: 400
+          unitAmount: 400,
+          locale: 'en_US'
         },
         purchasableType: 'bundle'
       }),
@@ -361,7 +366,8 @@ describe('totalLineOneMulticurrency', function () {
           {
             quantity: 1,
             price: {
-              unitAmount: 200000
+              unitAmount: 200000,
+              locale: 'en_US'
             }
           },
           'usd'
@@ -376,12 +382,13 @@ describe('totalLineOneMulticurrency', function () {
           {
             quantity: 1,
             price: {
-              unitAmount: 4505
+              unitAmount: 4505,
+              locale: 'ja_JP'
             }
           },
           'jpy'
         ),
-        '¥4,505'
+        '￥4,505'
       );
     });
 
@@ -391,12 +398,14 @@ describe('totalLineOneMulticurrency', function () {
           {
             quantity: 1,
             price: {
-              unitAmount: 350002
+              unitAmount: 350002,
+              locale: 'de_AT'
             }
           },
           'eur'
         ),
-        '€3,500.02'
+        // space is character U+00a0
+        '€ 3.500,02'
       );
     });
 
@@ -407,7 +416,8 @@ describe('totalLineOneMulticurrency', function () {
             quantity: 1,
             coupon: { amountOffInCents: 2 },
             price: {
-              unitAmount: 2
+              unitAmount: 2,
+              locale: 'en_US'
             }
           },
           'usd'
@@ -523,7 +533,8 @@ describe('totalLineTwoMulticurrency', function () {
           interval: 'month',
           coupon: { amountOffInCents: 4, duration: 'once' },
           price: {
-            unitAmount: 6
+            unitAmount: 6,
+            locale: 'en_US'
           }
         }),
         '$0.06 / month'
@@ -538,7 +549,8 @@ describe('totalLineTwoMulticurrency', function () {
           interval: 'month',
           coupon: { amountOffInCents: 4, duration: 'once' },
           price: {
-            unitAmount: 6
+            unitAmount: 6,
+            locale: 'en_US'
           }
         }),
         '$0.60 / month'
@@ -554,7 +566,8 @@ describe('totalLineTwoMulticurrency', function () {
             interval: 'month',
             coupon: { amountOffInCents: 4, duration: 'once' },
             price: {
-              unitAmount: 6
+              unitAmount: 6,
+              locale: 'cy_GB'
             }
           },
           'gbp'


### PR DESCRIPTION
Another add on for CLM-11500. This will allow correct locale formatting for the checkout page

<img width="733" alt="Screenshot 2024-06-07 at 12 13 59 PM" src="https://github.com/thoughtindustries/couponable/assets/97185690/4c528015-0587-47fb-ac2c-a92ad1252af0">
